### PR TITLE
Return user if member isnt available

### DIFF
--- a/libs/client/Client.lua
+++ b/libs/client/Client.lua
@@ -218,13 +218,13 @@ local function ParseOptions(options, resolved)
 		if type == subCommandOptionType or type == subCommandGroupOptionType then
 			parsed_options[name] = ParseOptions(v.options, resolved)
 		elseif type == userOptionType then
-			parsed_options[name] = resolved.members[value]
+			parsed_options[name] = resolved.users[value]
 		elseif type == channelOptionType then
 			parsed_options[name] = resolved.channels[value]
 		elseif type == roleOptionType then
 			parsed_options[name] = resolved.roles[value]
 		elseif type == mentionableOptionType then
-			parsed_options[name] = (resolved.members and resolved.members[value]) or (resolved.roles and resolved.roles[value])
+			parsed_options[name] = (resolved.users and resolved.users[value]) or (resolved.roles and resolved.roles[value])
 		elseif type == attachmentOptionType then
 			parsed_options[name] = resolved.attachments[value]
 		else

--- a/libs/client/Client.lua
+++ b/libs/client/Client.lua
@@ -218,13 +218,13 @@ local function ParseOptions(options, resolved)
 		if type == subCommandOptionType or type == subCommandGroupOptionType then
 			parsed_options[name] = ParseOptions(v.options, resolved)
 		elseif type == userOptionType then
-			parsed_options[name] = resolved.users[value]
+			parsed_options[name] = (resolved.members and resolved.members[value]) or resolved.users
 		elseif type == channelOptionType then
 			parsed_options[name] = resolved.channels[value]
 		elseif type == roleOptionType then
 			parsed_options[name] = resolved.roles[value]
 		elseif type == mentionableOptionType then
-			parsed_options[name] = (resolved.users and resolved.users[value]) or (resolved.roles and resolved.roles[value])
+			parsed_options[name] = (resolved.members and resolved.members[value]) or (resolved.users and resolved.users[value]) or (resolved.roles and resolved.roles[value])
 		elseif type == attachmentOptionType then
 			parsed_options[name] = resolved.attachments[value]
 		else

--- a/libs/client/Client.lua
+++ b/libs/client/Client.lua
@@ -218,7 +218,7 @@ local function ParseOptions(options, resolved)
 		if type == subCommandOptionType or type == subCommandGroupOptionType then
 			parsed_options[name] = ParseOptions(v.options, resolved)
 		elseif type == userOptionType then
-			parsed_options[name] = (resolved.members and resolved.members[value]) or resolved.users
+			parsed_options[name] = (resolved.members and resolved.members[value]) or resolved.users[value]
 		elseif type == channelOptionType then
 			parsed_options[name] = resolved.channels[value]
 		elseif type == roleOptionType then


### PR DESCRIPTION
Since my last pull request there was an issue where if a global command had a role/user option would crash the bot if ran in DMs. (I'm sorry I didn't notice earlier)
How I fixed it was by just returning the user if member isn't available.

Also, probably not the best place to ask but in my last pull request you said you no longer want to maintain this. Are you still fine with pull requests or would you rather I keep my changes in my own fork?